### PR TITLE
Add ripgrep

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ If you want to contribute, please read [CONTRIBUTING.md](CONTRIBUTING.md).
 
 * [coreutils](https://github.com/uutils/coreutils) - Cross-platform Rust rewrite of the GNU coreutils
 
+#### grep
+
+* [ripgrep](https://github.com/BurntSushi/ripgrep) - Faster and more correct replacement for GNU grep that respects your gitignore.
+
 #### hexdump
 
 * [hexyl](https://github.com/sharkdp/hexyl) - A command-line hex viewer


### PR DESCRIPTION
The very first rust project that replaced a GNU system util for me

changelog: Added ripgrep as a grep replacement
